### PR TITLE
fix: fix announcement reappear

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -46,7 +46,6 @@ const Root = () => {
         subtitle="UBC iGEM 2024 is officially the Best Undergrad Team in North America this year! 🌎🥳 "
         link="https://2024.igem.wiki/ubc-vancouver/awards/"
         imageSource={NUCLOUD}
-        daysToLive={0}
         secondsBeforeBannerShows={0}
         closeIconSize={30}
         animateInDuration={500}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -47,6 +47,7 @@ const Root = () => {
         link="https://2024.igem.wiki/ubc-vancouver/awards/"
         imageSource={NUCLOUD}
         secondsBeforeBannerShows={0}
+        daysToLive={1}
         closeIconSize={30}
         animateInDuration={500}
         animateOutDuration={500}


### PR DESCRIPTION
Removing the daysToLive={0} property causes the announcement component to reappear unexpectedly, as this property determines how long the dismissal is remembered after the user closes it.