### PR TITLE
feat: implement table of contents

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,122 @@
+---
+interface Props {
+  entries: {
+    title: string;
+    fragment: string;
+  }[];
+}
+
+const { entries } = Astro.props
+---
+
+<div class="table-of-contents collapsed">
+  {
+    entries.map(entry => (
+      <div class="indicator" data-entry={entry.fragment} />
+    ))
+  }
+</div>
+<div class="table-of-contents expanded">
+  {
+    entries.map(entry => (
+      <a href={`#${entry.fragment}`} class="entry" data-entry={entry.fragment}>
+        <p>{entry.title}</p>
+      </a>
+    ))
+  }
+</div>
+
+<script is:inline>
+  window.addEventListener('DOMContentLoaded', () => {
+    const pageEntries = document.querySelectorAll('section[id]')
+    const tocEntries = document.querySelectorAll('[data-entry]')
+
+    const isSmallScreen = window.matchMedia('(max-width: 1000px)')
+
+    const observerOptions = {
+      root: null,
+      rootMargin: '-50px',
+      threshold: isSmallScreen ? 0.3 : 0.8
+    }
+
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          tocEntries.forEach(tocEntry => tocEntry.classList.toggle('selected', tocEntry.dataset.entry === entry.target.id))
+        }
+      })
+    }, observerOptions)
+
+    pageEntries.forEach(pageEntry => observer.observe(pageEntry))
+  })
+</script>
+
+<style>
+  .table-of-contents {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 50%;
+    right: 10px;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 0.9rem;
+    transform: translateY(-50%);
+    transition: all 0.3s ease-in-out;
+  }
+
+  .table-of-contents.collapsed {
+    padding-left: 1rem;
+    gap: 1rem;
+    align-items: flex-end;
+  }
+
+  .table-of-contents.expanded {
+    width: 220px;
+    height: auto;
+    padding: 1rem;
+    background-color: var(--background-color);
+    border: solid 1px rgba(0, 0, 0, 0.1);
+    border-radius: var(--border-radius-md);
+    box-shadow: 1px 1px 5px 1px rgba(0, 0, 0, 0.1);
+    transform: translate(100%, -50%);
+    align-items: flex-start;
+    opacity: 0;
+  }
+
+  .table-of-contents.collapsed:hover ~ .table-of-contents.expanded,
+  .table-of-contents.expanded:hover {
+    transform: translate(0, -50%);
+    opacity: 100%;
+  }
+
+  .indicator {
+    width: 16px;
+    height: 2px;
+    background-color: var(--color-secondary-green);
+    border-radius: 2px;
+  }
+
+  .indicator.selected {
+    width: 20px;
+    background-color: var(--color-tertiary-green);
+  }
+
+  .entry {
+    width: 100%;
+    padding: 0.5rem;
+    border-radius: var(--border-radius-sm);
+  }
+
+  .entry:hover {
+    background-color: var(--color-secondary-green);
+  }
+
+  .entry p {
+    margin: 0;
+  }
+
+  .entry.selected {
+    color: var(--color-tertiary-green);
+    font-weight: bold;
+  }
+</style>

--- a/src/pages/our-team.astro
+++ b/src/pages/our-team.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro'
 import MemberCard from '../components/MemberCard.astro'
+import TableOfContents from '../components/TableOfContents.astro'
 import team from '../data/team.json'
 
 interface Member {
@@ -42,6 +43,14 @@ const subteamKeys = Object.keys(team) as (keyof typeof team)[]
         )
       })
     }
+    <TableOfContents
+      entries={subteamKeys.map(subteamKey => {
+        return {
+          title: team[subteamKey].title,
+          fragment: subteamKey
+        }
+      })}
+    />
   </div>
 </Layout>
 


### PR DESCRIPTION
Implemented the table of contents with both a 'collapsed' and 'expanded' version.

**note:** We can consider adding the table of contents to the other pages as well.

<img width="1000" alt="Table of Contents Collapsed" src="https://github.com/user-attachments/assets/9b92b03e-c2ce-4df3-8864-026ef15eca9f" />

<img width="1000" alt="Table of Contents Expanded" src="https://github.com/user-attachments/assets/0644319e-6b20-4141-9449-7786ac1596f5" />
