### PR TITLE
fix: fixing mobile version block size

### DIFF
--- a/src/components/projectsComponents/ProjectBlock.astro
+++ b/src/components/projectsComponents/ProjectBlock.astro
@@ -158,7 +158,6 @@ export interface Props {
         padding: var(--project-container-padding);
         border: 2px solid var(--color-primary-black);
         border-radius: var(--border-radius-md);
-        min-width: var(--project-container-min-width);
         box-shadow: rgba(0, 0, 0, 0.4) 5px 5px 5.3px;
         position:relative;
     }
@@ -249,7 +248,7 @@ export interface Props {
         }
 
         .project-title {
-            font-size: 2.5rem;
+            font-size: 2.1rem;
         }
 
         .project-container {

--- a/src/pages/past-projects.astro
+++ b/src/pages/past-projects.astro
@@ -62,6 +62,10 @@ import Layout from '../layouts/Layout.astro';
             border-right:0;
         }
 
+        #page-title {
+            font-size: 3.889rem;
+        }
+
         .title-container {
             padding-left: 4rem;
         }


### PR DESCRIPTION
I saw that for the mobile version in past-projects page still has some centering issues for smaller screen size, this PR should resolve it.
Below is what it looks like now.


![image](https://github.com/user-attachments/assets/b69f9050-425a-4336-a58d-0878bff2c22f)

